### PR TITLE
feat(chat): 채팅 기능 기본구조 구현(#6)

### DIFF
--- a/backendProject/build.gradle
+++ b/backendProject/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 	/* JSONObject */
 	implementation 'org.json:json:20240303'
 
+	/* env 파일 springboot 에서 사용을 위해 */
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
 }
 
 tasks.named('test') {

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatController.java
@@ -1,0 +1,20 @@
+package likelion.mlb.backendProject.domain.chat.controller;
+
+import likelion.mlb.backendProject.domain.chat.dto.ChatMessageDto;
+import likelion.mlb.backendProject.domain.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+  private final ChatService chatService;
+
+  @MessageMapping("/chat.send")
+  public void sendMessage(@Payload ChatMessageDto dto) {
+    chatService.sendMessage(dto);
+  }
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/dto/ChatMessageDto.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/dto/ChatMessageDto.java
@@ -1,0 +1,24 @@
+package likelion.mlb.backendProject.domain.chat.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import likelion.mlb.backendProject.domain.chat.entity.ChatMessage.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatMessageDto {
+
+  private UUID id;
+  private UUID roomId;
+  private UUID userId;
+  private MessageType messageType;
+  private String content;
+  private LocalDateTime sentAt;
+
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/entity/ChatMessage.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/entity/ChatMessage.java
@@ -27,7 +27,7 @@ public class ChatMessage {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "messagetype", nullable = false)
-    private MessageType messagetype;
+    private MessageType messageType;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/entity/ChatRoom.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/entity/ChatRoom.java
@@ -1,6 +1,8 @@
 package likelion.mlb.backendProject.domain.chat.entity;
 
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import likelion.mlb.backendProject.domain.draft.entity.Draft;
 import lombok.Getter;
 import lombok.Setter;
@@ -24,4 +26,21 @@ public class ChatRoom {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "draft_id", nullable = false)
     private Draft draft;
+
+    @OneToMany(
+        mappedBy = "chatRoom",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
+    )
+    private List<ChatMessage> messages = new ArrayList<>();
+
+    public void addMessage(ChatMessage msg) {
+        messages.add(msg);
+        msg.setChatRoom(this);
+    }
+
+    public void removeMessage(ChatMessage msg) {
+        messages.remove(msg);
+        msg.setChatRoom(null);
+    }
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/repository/ChatMessageRepository.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package likelion.mlb.backendProject.domain.chat.repository;
+
+import java.util.UUID;
+import likelion.mlb.backendProject.domain.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> {
+
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/repository/ChatRoomRepository.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,11 @@
+package likelion.mlb.backendProject.domain.chat.repository;
+
+import java.util.UUID;
+import likelion.mlb.backendProject.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom,UUID> {
+
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/service/ChatService.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/service/ChatService.java
@@ -1,0 +1,11 @@
+package likelion.mlb.backendProject.domain.chat.service;
+
+import likelion.mlb.backendProject.domain.chat.dto.ChatMessageDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ChatService {
+
+  void sendMessage(ChatMessageDto dto);
+
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/service/Impl/ChatServiceImpl.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/service/Impl/ChatServiceImpl.java
@@ -1,0 +1,51 @@
+package likelion.mlb.backendProject.domain.chat.service.Impl;
+
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import likelion.mlb.backendProject.domain.chat.dto.ChatMessageDto;
+import likelion.mlb.backendProject.domain.chat.entity.ChatMessage;
+import likelion.mlb.backendProject.domain.chat.entity.ChatRoom;
+import likelion.mlb.backendProject.domain.chat.repository.ChatMessageRepository;
+import likelion.mlb.backendProject.domain.chat.repository.ChatRoomRepository;
+import likelion.mlb.backendProject.domain.chat.service.ChatService;
+import likelion.mlb.backendProject.domain.user.entity.User;
+import likelion.mlb.backendProject.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+  private final UserRepository userRepo;
+  private final ChatRoomRepository roomRepo;
+  private final ChatMessageRepository messageRepo;
+  private final SimpMessagingTemplate template;
+
+  public void sendMessage(ChatMessageDto dto){
+    //어떤 방에다가 넣어줄지
+    ChatRoom room = roomRepo.findById(dto.getRoomId())
+        .orElseThrow(() -> new IllegalArgumentException("Invalid room ID: " + dto.getRoomId()));
+
+    ChatMessage msg = new ChatMessage();
+    msg.setId(UUID.randomUUID());
+    msg.setChatRoom(room);
+    msg.setContent(dto.getContent());
+    msg.setMessageType(dto.getMessageType());
+    msg.setCreatedAt(LocalDateTime.now());
+    //유저
+    if (dto.getUserId() != null) {
+      User user = userRepo.findById(dto.getUserId())
+          .orElseThrow(() -> new IllegalArgumentException("Invalid user ID: " + dto.getUserId()));
+    }
+    messageRepo.save(msg);
+
+    dto.setId(msg.getId());
+    dto.setSentAt(msg.getCreatedAt());
+
+    String dest = "/topic/chat/" + dto.getRoomId();
+    template.convertAndSend(dest, dto);
+  }
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/WebSocketConfig.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/WebSocketConfig.java
@@ -1,0 +1,43 @@
+package likelion.mlb.backendProject.global.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * WebSocket/STOMP 설정 클래스
+ * - 클라이언트는 /ws-chat 엔드포인트로 연결
+ * - 메시지는 /app 접두어로 들어와서, /topic 브로커로 전달됨
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  /**
+   * 메시지 브로커 설정
+   * - enableSimpleBroker: 서버에서 구독한 클라이언트로 메시지를 브로드캐스트할 경로
+   * - setApplicationDestinationPrefixes: 클라이언트 메시지가
+   * @MessageMapping으로 라우팅될 경로
+   */
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    config.enableSimpleBroker("/topic");
+    config.setApplicationDestinationPrefixes("/app");
+  }
+
+  /**
+   * STOMP 엔드포인트 등록
+   * - /ws-chat: WebSocket 연결을 위한 엔드포인트 - withSockJS(): SockJS 폴백 옵션 활성화
+   * - setAllowedOriginPatterns("*"):
+   * 모든 출처 허용 (필요 시 도메인 제한)
+   */
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws-chat")
+        .setAllowedOriginPatterns("*")
+        .withSockJS();
+  }
+}
+


### PR DESCRIPTION
Changes
---
- DTO 정의
– ChatMessageDto로 WebSocket을 통해 주고받을 메시지 구조 정의
- WebSocket 설정
– WebSocketConfig에서 /ws-chat 엔드포인트 등록
– 클라이언트 메시지는 /app/* 으로 받고, 서버 -> 클라이언트는 /topic/* 으로 브로드캐스트 
- JPA 리포지토리
– ChatRoomRepository, ChatMessageRepository
- Service
– ChatService 인터페이스 및 ChatServiceImpl 구현
– 메시지 저장 시 유저 지정, 생성 시간 설정, /topic/chat/{roomId} 으로 DTO 전송 WebSocket 컨트롤러
– @MessageMapping("/chat.send") 으로 클라이언트 메시지 수신
---

#6 

close #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 실시간 채팅 기능이 추가되었습니다. 이제 웹소켓을 통해 채팅 메시지를 주고받을 수 있습니다.
  * 채팅방 및 메시지 저장 기능이 도입되어, 채팅 내역이 관리됩니다.

* **버그 수정**
  * 메시지 타입 필드명이 일관성 있게 수정되었습니다.

* **기타**
  * 환경 변수 파일(.env) 지원이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->