### PR TITLE
feat(draft) 웹소켓 드래프트 기능 완성

### DIFF
--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/controller/DraftController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/controller/DraftController.java
@@ -2,6 +2,7 @@ package likelion.mlb.backendProject.domain.draft.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import likelion.mlb.backendProject.domain.draft.dto.DraftParticipant;
 import likelion.mlb.backendProject.domain.draft.dto.DraftRequest;
 import likelion.mlb.backendProject.domain.draft.dto.DraftResponse;
 import likelion.mlb.backendProject.domain.draft.service.DraftService;
@@ -12,9 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
 import java.security.Principal;
 import java.util.*;
 
@@ -51,8 +51,38 @@ public class DraftController {
     /*
     * 참여자(participant)클릭 시 해당 참여자가 선택한 선수 리스트 가져오기
     * */
-    @GetMapping("/players/{participantId}")
+    @GetMapping("/{participantId}/players")
+    @ResponseBody
     public List<DraftResponse> getPlayersByParticipantId(@PathVariable("participantId") UUID participantId) {
         return draftService.getPlayersByParticipantId(participantId);
+    }
+
+
+    /*
+     * 드래프트 방 입장 시 해당 드래프트 방에 속해 있는 4명의 참여자 리스트 가져오기
+     */
+    @GetMapping("/{draftId}/participants")
+    @ResponseBody
+    public List<DraftParticipant> getParticipantsByDraftId(@PathVariable("draftId") UUID draftId) {
+        return draftService.getParticipantsByDraftId(draftId);
+    }
+
+    /*
+     * 해당 드래프트 방에서 선택 된 선수 리스트 가져오기
+     */
+    @GetMapping("/{draftId}/allPlayers")
+    @ResponseBody
+    public List<DraftResponse> getAllPlayersByDraftId(@PathVariable("draftId") UUID draftId) {
+        return draftService.getAllPlayersByDraftId(draftId);
+    }
+
+    /*
+     * isWithinSquadLimits테스트용
+     */
+    @GetMapping("squadLimit")
+    @ResponseBody
+    public boolean isWithinSquadLimits(@RequestParam(value="participantId") UUID participantId,
+                                                      @RequestParam(value="participantId")UUID elementTypeId) {
+        return draftService.isWithinSquadLimitsTest(participantId, elementTypeId);
     }
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/DraftParticipant.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/DraftParticipant.java
@@ -1,0 +1,31 @@
+package likelion.mlb.backendProject.domain.draft.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+
+/*
+* 드래프트 방에 참여한 참여자 리스트 가져오는 dto
+* */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DraftParticipant {
+
+    private UUID participantId; // participant pk값
+
+    private short participantUserNumber; // 드래프트 방에서 참여자 순서
+
+    private boolean participantDummy; // 더미 여부(봇 여부)
+
+    private String userEmail; // 이메일
+
+    private String userName; // 참여자명
+
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/DraftRequest.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/DraftRequest.java
@@ -18,15 +18,17 @@ public class DraftRequest {
 
     private UUID playerId; // player pk값
 
-    private String PlayerWebName; // player 영어 이름
+    private String playerWebName; // player 영어 이름
 
-    private String PlayerKrName; // player 한글 이름
+    private String playerKrName; // player 한글 이름
 
-    private String PlayerPic; // player 사진
+    private String playerPic; // player 사진
 
     private String teamName; // 소속팀 영어명
 
     private String teamKrName; // 소속팀 한글명
+
+    private UUID elementTypeId; // 포지션 pk값
 
     private String elementTypePluralName; // 포지션 영어명
 
@@ -34,5 +36,8 @@ public class DraftRequest {
 
     // 선택한 선수가 이미 선택 되었는 지 여부
     private boolean alreadySelected = false;
+
+    // 한 참가자가 선수를 드래프트 했을 시 포지션 별 최대/최소 값 유지하는 지 여부
+    private boolean isWithinSquadLimits = true;
 
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/DraftResponse.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/DraftResponse.java
@@ -17,15 +17,19 @@ public class DraftResponse {
 
     private UUID playerId; // player pk값
 
-    private String PlayerWebName; // player 영어 이름
+    private String playerWebName; // player 영어 이름
 
-    private String PlayerKrName; // player 한글 이름
+    private String playerKrName; // player 한글 이름
 
-    private String PlayerPic; // player 사진
+    private String playerPic; // player 사진
+
+    private UUID teamId; // 소속팀 pk값
 
     private String teamName; // 소속팀 영어명
 
     private String teamKrName; // 소속팀 한글명
+
+    private UUID elementTypeId; // 포지션 pk값
 
     private String elementTypePluralName; // 포지션 영어명
 

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/entity/ParticipantPlayer.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/entity/ParticipantPlayer.java
@@ -4,9 +4,7 @@ import jakarta.persistence.*;
 import likelion.mlb.backendProject.domain.draft.dto.DraftResponse;
 import likelion.mlb.backendProject.domain.match.entity.Participant;
 import likelion.mlb.backendProject.domain.player.entity.Player;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -16,6 +14,8 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ParticipantPlayer {
 
     @Id
@@ -38,15 +38,17 @@ public class ParticipantPlayer {
         return players.stream().map(p -> DraftResponse.builder()
                 .participantId(p.getParticipant().getId())
                 .playerId(p.getPlayer().getId())
-                .PlayerWebName(p.getPlayer().getWebName())
-                .PlayerKrName(p.getPlayer().getKrName())
-                .PlayerPic(p.getPlayer().getPic())
+                .playerWebName(p.getPlayer().getWebName())
+                .playerKrName(p.getPlayer().getKrName())
+                .playerPic(p.getPlayer().getPic())
 
                 // team관련 설정
+                .teamId(p.getPlayer().getTeam().getId())
                 .teamName(p.getPlayer().getTeam().getName())
                 .teamKrName(p.getPlayer().getTeam().getKrName())
 
                 // 포지션(elementType) 관련 설정
+                .elementTypeId(p.getPlayer().getElementType().getId())
                 .elementTypePluralName(p.getPlayer().getElementType().getPluralName())
                 .elementTypeKrName(p.getPlayer().getElementType().getKrName())
                 .build()

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/repository/ParticipantPlayerRepository.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/repository/ParticipantPlayerRepository.java
@@ -39,4 +39,29 @@ public interface ParticipantPlayerRepository extends JpaRepository<ParticipantPl
     """)
     List<Object[]> sumPointsByParticipant(@Param("round") Round round,
                                           @Param("participants") List<Participant> participants);
+
+    /*
+    * 한 참가자가 선수를 드래프트 했을 시 포지션 별 최대/최소 값 유지하는 지 확인
+    * */
+    @Query("""
+        SELECT CASE
+            WHEN ((SELECT COUNT(pp)
+                   FROM Player p
+                   LEFT JOIN ParticipantPlayer pp
+                     ON pp.player = p
+                     AND pp.participant.id = :participantId
+                   WHERE p.elementType.id = :elementTypeId) + 1) <= et.squadMaxPlay
+            THEN true
+            ELSE false
+        END
+        FROM ElementType et
+        WHERE et.id = :elementTypeId
+    """)
+    Boolean isWithinSquadLimits(
+            @Param("participantId") UUID participantId,
+            @Param("elementTypeId") UUID elementTypeId
+    );
+
+    // draftId로 ParticipantPlayer 전부 가져오기
+    List<ParticipantPlayer> findByParticipant_Draft_Id(UUID draftId);
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/entity/Participant.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/entity/Participant.java
@@ -1,17 +1,24 @@
 package likelion.mlb.backendProject.domain.match.entity;
 
 import jakarta.persistence.*;
+
+import likelion.mlb.backendProject.domain.draft.dto.DraftParticipant;
 import likelion.mlb.backendProject.domain.draft.entity.Draft;
 import likelion.mlb.backendProject.domain.user.entity.User;
-import lombok.Getter;
-import lombok.Setter;
 
+import lombok.*;
+
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "participant")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Participant {
 
     @Id
@@ -42,5 +49,23 @@ public class Participant {
         this.score = leaguePoint;
         this.rank = rank;
 
+    }
+
+    /**
+     * Participant 엔티티 리스트 → DraftParticipant 리스트 변환
+     */
+    public static List<DraftParticipant> toDtoList(List<Participant> participants) {
+
+        return participants.stream().map(p -> DraftParticipant.builder()
+
+                .participantId(p.getId())
+                .participantUserNumber(p.getUserNumber())
+                .participantDummy(p.isDummy())
+
+                .userEmail(p.getUser() != null ? p.getUser().getEmail() : null)
+                .userName(p.getUser() != null ? p.getUser().getName() : null)
+
+                .build()
+        ).collect(Collectors.toList());
     }
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/repository/ParticipantRepository.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/repository/ParticipantRepository.java
@@ -10,12 +10,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 //FIXME 주석 추가할 것
 public interface ParticipantRepository extends JpaRepository<Participant, UUID> {
-  boolean existsByDraft_IdAndUser_Id(UUID draftId, UUID userId);
+    boolean existsByDraft_IdAndUser_Id(UUID draftId, UUID userId);
 
 
     @Query("""
@@ -29,5 +30,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, UUID> 
     AssignDto findAssignment(@Param("userId") UUID userId,
                              @Param("roundId") UUID roundId);
 
-  Optional<Participant> findByUserAndDraft(User user, Draft draft);
+    Optional<Participant> findByUserAndDraft(User user, Draft draft);
+
+    List<Participant> findByDraft(Draft draft);
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/player/entity/ElementType.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/player/entity/ElementType.java
@@ -1,10 +1,7 @@
 package likelion.mlb.backendProject.domain.player.entity;
 
 import jakarta.persistence.*;
-import likelion.mlb.backendProject.domain.draft.dto.DraftResponse;
 import likelion.mlb.backendProject.domain.player.dto.ElementTypeDto;
-import likelion.mlb.backendProject.domain.player.dto.PreviousBestPlayerDto;
-import likelion.mlb.backendProject.domain.player.entity.live.PlayerFixtureStat;
 import likelion.mlb.backendProject.global.staticdata.dto.bootstrap.FplElementType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/DraftWebSocketConfig.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/DraftWebSocketConfig.java
@@ -1,0 +1,237 @@
+package likelion.mlb.backendProject.global.configuration;
+
+import likelion.mlb.backendProject.domain.chat.repository.ChatRoomRepository;
+import likelion.mlb.backendProject.domain.draft.repository.DraftRepository;
+import likelion.mlb.backendProject.domain.match.repository.ParticipantRepository;
+import likelion.mlb.backendProject.global.security.jwt.JwtTokenProvider;
+import likelion.mlb.backendProject.domain.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@Slf4j
+public class DraftWebSocketConfig implements WebSocketMessageBrokerConfigurer, ApplicationContextAware {
+
+  private ApplicationContext applicationContext;
+
+  @Override
+  public void setApplicationContext(ApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    config.enableSimpleBroker("/topic");
+    config.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // Draft Endpoint
+    registry.addEndpoint("/ws-draft")
+            .setAllowedOriginPatterns("*")
+            .addInterceptors(new HandshakeInterceptor() {
+              @Override
+              public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                             WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+                String query = request.getURI().getQuery();
+                String token = null;
+                if (query != null) {
+                  String[] params = query.split("&");
+                  for (String param : params) {
+                    if (param.startsWith("token=")) {
+                      token = param.substring(6);
+                      try {
+                        token = java.net.URLDecoder.decode(token, "UTF-8");
+                      } catch (Exception ignored) {}
+                      break;
+                    }
+                  }
+                }
+
+                if (token != null && token.startsWith("Bearer ")) {
+                  token = token.substring(7);
+                }
+
+                if (token != null && applicationContext.getBean(JwtTokenProvider.class).validateToken(token)) {
+                  String email = applicationContext.getBean(JwtTokenProvider.class).getEmail(token);
+                  var user = applicationContext.getBean(UserRepository.class)
+                          .findByEmail(email)
+                          .orElseThrow(() -> new IllegalArgumentException("User not found: " + email));
+
+                  var cud = new likelion.mlb.backendProject.global.security.dto.CustomUserDetails(user);
+                  var auth = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                          cud, null, cud.getAuthorities()
+                  );
+
+                  // 세션에 Principal 저장
+                  attributes.put("user", auth);
+                  attributes.put("principal", auth);
+
+                } else {
+                  throw new RuntimeException(new java.nio.file.AccessDeniedException("Invalid or missing token"));
+                }
+
+                return true;
+              }
+
+              @Override
+              public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                         WebSocketHandler wsHandler, Exception exception) {}
+            })
+            // ✅ (옵션 A) Principal을 세션 속성이 아닌 실제 Principal로 등록
+            .setHandshakeHandler(new DefaultHandshakeHandler() {
+              @Override
+              protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler,
+                                                Map<String, Object> attributes) {
+                // beforeHandshake에서 저장한 Authentication 꺼내서 Principal로 리턴
+                return (Principal) attributes.get("principal");
+              }
+            })
+            .withSockJS();
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(new ChannelInterceptor() {
+
+      private ParticipantRepository participantRepo;
+      private ChatRoomRepository chatRoomRepo;
+      private DraftRepository draftRepo;
+      private JwtTokenProvider jwtTokenProvider;
+      private UserRepository userRepository;
+      private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+
+      private void ensureBeans() {
+        if (participantRepo == null) {
+          participantRepo   = applicationContext.getBean(ParticipantRepository.class);
+          chatRoomRepo      = applicationContext.getBean(ChatRoomRepository.class);
+          draftRepo         = applicationContext.getBean(DraftRepository.class);
+          jwtTokenProvider  = applicationContext.getBean(JwtTokenProvider.class);
+          userRepository    = applicationContext.getBean(UserRepository.class);
+          objectMapper      = applicationContext.getBean(com.fasterxml.jackson.databind.ObjectMapper.class);
+        }
+      }
+
+      @Override
+      public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        ensureBeans();
+        var accessor = StompHeaderAccessor.wrap(message);
+
+        // 현재 메시지의 Principal이 없으면 세션에서 꺼내서 복원
+        if (accessor.getUser() == null) {
+          Object userAttr = accessor.getSessionAttributes().get("user");
+
+          // 세션에 저장된 객체가 Authentication 타입이면 Principal로 설정
+          if (userAttr instanceof Authentication auth) {
+            accessor.setUser(auth);
+          }
+        }
+
+        // 1. CONNECT: User Authentication
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+          Object userAttr = accessor.getSessionAttributes().get("user");
+          if (userAttr instanceof Authentication auth) {
+            accessor.setUser(auth);
+          } else {
+            throw new RuntimeException(new AccessDeniedException("Unauthenticated"));
+          }
+        }
+
+        // 2. SUBSCRIBE: Authorization for Topic
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+          var auth = (org.springframework.security.core.Authentication) accessor.getUser();
+          if (auth == null) throw new RuntimeException(new java.nio.file.AccessDeniedException("Unauthenticated"));
+          var cud    = (likelion.mlb.backendProject.global.security.dto.CustomUserDetails) auth.getPrincipal();
+          var userId = cud.getUser().getId();
+          String dest = accessor.getDestination();
+          if (dest == null) {
+            throw new RuntimeException(new java.nio.file.AccessDeniedException("Destination required"));
+          }
+
+          // Draft Subscription
+          if (dest != null && dest.matches("^/topic/draft.[0-9a-fA-F\\-]{36}$")) {
+
+            String draftIdStr = dest.substring("/topic/draft.".length());
+            var draftId = java.util.UUID.fromString(draftIdStr);
+            if (!participantRepo.existsByDraft_IdAndUser_Id(draftId, userId)) {
+              throw new RuntimeException(new java.nio.file.AccessDeniedException("No permission for this draft"));
+            }
+          }
+
+        }
+
+        // 3. SEND: Authorization for Message
+        if (StompCommand.SEND.equals(accessor.getCommand())) {
+
+          var auth = (org.springframework.security.core.Authentication) accessor.getUser();
+          if (auth == null) throw new RuntimeException(new java.nio.file.AccessDeniedException("Unauthenticated"));
+          var cud    = (likelion.mlb.backendProject.global.security.dto.CustomUserDetails) auth.getPrincipal();
+          var userId = cud.getUser().getId();
+          String dest = accessor.getDestination();
+          if (dest == null) {
+            throw new RuntimeException(new java.nio.file.AccessDeniedException("Destination required"));
+          }
+
+          // Draft Message
+          if ("/app/draft/selectPlayer".equals(dest)) {
+            java.util.UUID draftId = getDraftIdFromPayloadOrHeader(message, accessor); // Assuming payload contains draftId as 'roomId'
+            if (!participantRepo.existsByDraft_IdAndUser_Id(draftId, userId)) {
+              throw new RuntimeException(new java.nio.file.AccessDeniedException("No permission to send message to this draft"));
+            }
+          }
+
+        }
+        return message;
+      }
+
+      private java.util.UUID getDraftIdFromPayloadOrHeader(Message<?> message, StompHeaderAccessor accessor) {
+        // 1) 헤더 우선: X-DRAFT-ID 또는 X-ROOM-ID(하위호환)
+        String h1 = accessor.getFirstNativeHeader("X-DRAFT-ID");
+        if (h1 != null && !h1.isBlank()) return java.util.UUID.fromString(h1);
+
+        String h2 = accessor.getFirstNativeHeader("X-ROOM-ID"); // 기존 호환
+        if (h2 != null && !h2.isBlank()) return java.util.UUID.fromString(h2);
+
+        // 2) 바디에서 찾기: draftId 우선, 없으면 roomId(하위호환)
+        Object payload = message.getPayload();
+        if (payload instanceof byte[] body) {
+          try {
+            var node = objectMapper.readTree(body);
+            String did = node.hasNonNull("draftId") ? node.get("draftId").asText(null) : null;
+            if (did != null) return java.util.UUID.fromString(did);
+            String rid = node.hasNonNull("roomId") ? node.get("roomId").asText(null) : null;
+            if (rid != null) return java.util.UUID.fromString(rid);
+          } catch (Exception ignore) {}
+        }
+
+        throw new RuntimeException(new java.nio.file.AccessDeniedException("draftId header/body required"));
+      }
+
+
+    });
+  }
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/RedisConfig.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/RedisConfig.java
@@ -61,7 +61,7 @@ public class RedisConfig {
   public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
     RedisMessageListenerContainer container = new RedisMessageListenerContainer();
     container.setConnectionFactory(connectionFactory);
-    container.addMessageListener(new MessageListenerAdapter(redisSubscriber), new PatternTopic("room.*"));
+    container.addMessageListener(new MessageListenerAdapter(redisSubscriber), new PatternTopic("draft.*"));
     return container;
   }
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/WebSocketConfig.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/WebSocketConfig.java
@@ -1,8 +1,17 @@
 package likelion.mlb.backendProject.global.configuration;
 
 import lombok.RequiredArgsConstructor;
+
+import likelion.mlb.backendProject.domain.chat.repository.ChatRoomRepository;
+import likelion.mlb.backendProject.domain.draft.repository.DraftRepository;
+import likelion.mlb.backendProject.domain.match.repository.ParticipantRepository;
+import likelion.mlb.backendProject.global.security.jwt.JwtTokenProvider;
+import likelion.mlb.backendProject.domain.user.repository.UserRepository;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -12,14 +21,20 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+import java.security.Principal;
+import java.util.Map;
 
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import likelion.mlb.backendProject.global.security.jwt.JwtTokenProvider;
 import likelion.mlb.backendProject.domain.chat.repository.ChatMembershipRepository;
 import likelion.mlb.backendProject.global.security.dto.CustomUserDetails;
 
@@ -44,7 +59,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void configureClientInboundChannel(ChannelRegistration registration) {
-
     // 1) CONNECT 시 JWT 인증 처리 (런타임 조회)
     ChannelInterceptor jwtConnect = new ChannelInterceptor() {
       @Override

--- a/backendProject/src/main/resources/static/draft/websocket.html
+++ b/backendProject/src/main/resources/static/draft/websocket.html
@@ -151,7 +151,7 @@
 
 
                     //일반채팅
-                    stompClient.subscribe(`/topic/draft.a1c2d3e4-f5b6-4789-9abc-1234567890ab`, function (chat) {
+                    stompClient.subscribe(`/topic/draft/a1c2d3e4-f5b6-4789-9abc-1234567890ab`, function (chat) {
                         const message = JSON.parse(chat.body);
                         showMessage(message.participantId, message.playerId);
                     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 드래프트 참가자 조회 및 드래프트 내 전체 선택 선수 조회 API 추가
  - 스쿼드 포지션 한도 검증 API 추가
  - 드래프트 실시간(WebSocket) 연결에 JWT 인증/권한 적용
- Refactor
  - 실시간 채널/구독 경로를 draft.* → draft/{draftId} 형태로 정비
  - 참가자별 선수 조회 경로를 /players/{participantId} → /{participantId}/players로 정리
  - API 필드 네이밍을 camelCase로 통일(playerWebName 등)
- Chores
  - Redis 구독 토픽을 draft.*로 변경
  - 테스트용 드래프트 웹소켓 페이지 구독 경로 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->