### PR TITLE
feat(chat): 유저별 점수 및 순위, 드래프트 포메이션 정보를 가져오기 위한 백엔드 API 추가 구현 (#74)

### DIFF
--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatRoomQueryController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatRoomQueryController.java
@@ -1,0 +1,34 @@
+package likelion.mlb.backendProject.domain.chat.controller;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import likelion.mlb.backendProject.domain.chat.dto.ScoreboardItem;
+import likelion.mlb.backendProject.domain.chat.dto.RosterResponse;
+import likelion.mlb.backendProject.domain.chat.service.ChatRoomQueryService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat-rooms")
+public class ChatRoomQueryController {
+
+  private final ChatRoomQueryService queryService;
+
+  /**
+   * 방 스코어보드 (4명, 점수/랭크)
+   */
+  @GetMapping("/{roomId}/scoreboard")
+  public List<ScoreboardItem> scoreboard(@PathVariable UUID roomId) {
+    return queryService.getScoreboard(roomId);
+  }
+
+  /**
+   * 특정 참가자의 로스터(11인) + 포메이션
+   */
+  @GetMapping("/{roomId}/participants/{participantId}/roster")
+  public RosterResponse roster(@PathVariable UUID roomId, @PathVariable UUID participantId) {
+    return queryService.getRoster(roomId, participantId);
+  }
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/dto/RosterResponse.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/dto/RosterResponse.java
@@ -1,0 +1,30 @@
+package likelion.mlb.backendProject.domain.chat.dto;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RosterResponse {
+
+  private UUID participantId;
+  private String formation; // 예: "4-3-3" (GK 제외, DF-MID-FWD)
+  private List<PlayerSlot> players;
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class PlayerSlot {
+
+    private UUID playerId;
+    private String name;
+    private String position; // GK/DEF/MID/FWD
+    private String team;     // 팀 이름(옵션)
+  }
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/dto/ScoreboardItem.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/dto/ScoreboardItem.java
@@ -1,0 +1,13 @@
+package likelion.mlb.backendProject.domain.chat.dto;
+
+import java.util.UUID;
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ScoreboardItem {
+  private UUID participantId;
+  private UUID userId;        // 봇이면 null
+  private String email;       // 봇이면 "BOT"
+  private long totalPoints;   // 라운드 퍼포먼스 합계
+  private int rank;           // 1~4
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/service/ChatRoomQueryService.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/service/ChatRoomQueryService.java
@@ -1,0 +1,15 @@
+package likelion.mlb.backendProject.domain.chat.service;
+
+import java.util.List;
+import java.util.UUID;
+import likelion.mlb.backendProject.domain.chat.dto.RosterResponse;
+import likelion.mlb.backendProject.domain.chat.dto.ScoreboardItem;
+
+public interface ChatRoomQueryService {
+
+  /** 방 스코어보드(4명, 퍼포먼스 합계 기준 랭킹) */
+  List<ScoreboardItem> getScoreboard(UUID roomId);
+
+  /** 특정 참가자의 로스터(11인) + 포메이션 계산 */
+  RosterResponse getRoster(UUID roomId, UUID participantId);
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/service/Impl/ChatRoomQueryServiceImpl.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/service/Impl/ChatRoomQueryServiceImpl.java
@@ -1,0 +1,149 @@
+package likelion.mlb.backendProject.domain.chat.service.Impl;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import likelion.mlb.backendProject.domain.chat.dto.RosterResponse;
+import likelion.mlb.backendProject.domain.chat.dto.ScoreboardItem;
+import likelion.mlb.backendProject.domain.chat.entity.ChatRoom;
+import likelion.mlb.backendProject.domain.chat.repository.ChatRoomRepository;
+import likelion.mlb.backendProject.domain.chat.service.ChatRoomQueryService;
+
+import likelion.mlb.backendProject.domain.draft.entity.ParticipantPlayer;
+import likelion.mlb.backendProject.domain.draft.repository.DraftRepository;
+import likelion.mlb.backendProject.domain.draft.repository.ParticipantPlayerRepository;
+
+import likelion.mlb.backendProject.domain.match.entity.Participant;
+import likelion.mlb.backendProject.domain.match.repository.ParticipantRepository;
+
+import likelion.mlb.backendProject.domain.round.entity.Round;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
+
+  private final ChatRoomRepository chatRoomRepository;
+  private final DraftRepository draftRepository;
+  private final ParticipantRepository participantRepository;
+  private final ParticipantPlayerRepository participantPlayerRepository;
+
+  /** roomId → draft/participants 로딩 */
+  private Loaded load(UUID roomId) {
+    ChatRoom room = chatRoomRepository.findById(roomId)
+        .orElseThrow(() -> new IllegalArgumentException("ChatRoom not found: " + roomId));
+
+    UUID draftId = room.getDraftId();
+    var draft = draftRepository.findById(draftId)
+        .orElseThrow(() -> new IllegalArgumentException("Draft not found: " + draftId));
+
+    List<Participant> participants = participantRepository.findByDraft(draft);
+    return new Loaded(draftId, draft.getRound(), participants);
+  }
+
+  /** 방 스코어보드: 퍼포먼스 합계 기준 4명 랭킹 */
+  @Override
+  public List<ScoreboardItem> getScoreboard(UUID roomId) {
+    var loaded = load(roomId);
+
+    Map<UUID, Participant> pMap = loaded.participants.stream()
+        .collect(Collectors.toMap(Participant::getId, p -> p));
+
+    // round + participants 로 합산 점수 집계 (없으면 0점 처리)
+    List<Object[]> rows = participantPlayerRepository
+        .sumPointsByParticipant(loaded.round, loaded.participants);
+
+    List<ScoreboardItem> items = new ArrayList<>();
+
+    // 점수 있는 참가자
+    for (Object[] r : rows) {
+      UUID participantId = (UUID) r[0];
+      long total = ((Number) r[1]).longValue();
+      Participant p = pMap.get(participantId);
+
+      String email = (p.isDummy() || p.getUser() == null) ? "BOT" : p.getUser().getEmail();
+      UUID userId = (p.isDummy() || p.getUser() == null) ? null : p.getUser().getId();
+
+      items.add(ScoreboardItem.builder()
+          .participantId(participantId)
+          .userId(userId)
+          .email(email)
+          .totalPoints(total)
+          .rank(0)
+          .build());
+    }
+
+    // 점수 레코드가 아직 없는 참가자도 0점으로 포함
+    Set<UUID> present = items.stream().map(ScoreboardItem::getParticipantId).collect(Collectors.toSet());
+    for (Participant p : loaded.participants) {
+      if (!present.contains(p.getId())) {
+        String email = (p.isDummy() || p.getUser() == null) ? "BOT" : p.getUser().getEmail();
+        UUID userId = (p.isDummy() || p.getUser() == null) ? null : p.getUser().getId();
+
+        items.add(ScoreboardItem.builder()
+            .participantId(p.getId())
+            .userId(userId)
+            .email(email)
+            .totalPoints(0L)
+            .rank(0)
+            .build());
+      }
+    }
+
+    // 내림차순 정렬 + 랭크 부여(동점 처리 단순화)
+    items.sort(Comparator.comparingLong(ScoreboardItem::getTotalPoints).reversed());
+    int rank = 1;
+    for (ScoreboardItem it : items) it.setRank(rank++);
+    return items;
+  }
+
+  /** 특정 참가자의 로스터(11인) + 포메이션 문자열 */
+  @Override
+  public RosterResponse getRoster(UUID roomId, UUID participantId) {
+    var loaded = load(roomId);
+
+    // 해당 방 소속 참가자인지 검증
+    boolean belongs = loaded.participants.stream().anyMatch(p -> p.getId().equals(participantId));
+    if (!belongs) throw new IllegalArgumentException("Participant not in this room: " + participantId);
+
+    List<ParticipantPlayer> picks = participantPlayerRepository.findByParticipant_Id(participantId);
+
+    int gk=0, df=0, mid=0, fwd=0;
+    List<RosterResponse.PlayerSlot> slots = new ArrayList<>();
+
+    for (var pp : picks) {
+      var pl = pp.getPlayer();
+      int type = pl.getElementType().getFplId(); // 1=GK, 2=DEF, 3=MID, 4=FWD
+
+      String pos = switch (type) {
+        case 1 -> "GK";
+        case 2 -> "DF";
+        case 3 -> "MID";
+        default -> "FWD";
+      };
+
+      if (type==1) gk++; else if (type==2) df++; else if (type==3) mid++; else fwd++;
+
+      slots.add(RosterResponse.PlayerSlot.builder()
+          .playerId(pl.getId())
+          .name(pl.getWebName() != null ? pl.getWebName() : pl.getKrName()) // 이름 소스 통일
+          .position(pos)
+          .team(pl.getTeam().getName())  // 필요 시 getKrName()으로 교체 가능
+          .build());
+    }
+
+    // 일반 표기: GK 제외 → DF-MID-FWD
+    String formation = String.format("%d-%d-%d", df, mid, fwd);
+
+    return RosterResponse.builder()
+        .participantId(participantId)
+        .formation(formation)
+        .players(slots)
+        .build();
+  }
+
+  private record Loaded(UUID draftId, Round round, List<Participant> participants) {}
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/entity/Participant.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/entity/Participant.java
@@ -21,51 +21,51 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class Participant {
 
-    @Id
-    @Column(name = "id", nullable = false)
-    private UUID id;
+  @Id
+  @Column(name = "id", nullable = false)
+  private UUID id;
 
-    @Column(name = "user_number", nullable = false)
-    private short userNumber;
+  @Column(name = "user_number", nullable = false)
+  private short userNumber;
 
-    @Column(name = "isDummy", nullable = false)
-    private boolean dummy;
+  @Column(name = "is_dummy", nullable = false)
+  private boolean dummy;
 
-    @Column(name = "score", nullable = false)
-    private Integer score = 0;
+  @Column(name = "score", nullable = false)
+  private Integer score = 0;
 
-    @Column(name = "rank")
-    private Integer rank;
+  @Column(name = "rank")
+  private Integer rank;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "draft_id", nullable = false)
-    private Draft draft;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "draft_id", nullable = false)
+  private Draft draft;
 
-    public void updateRank(int leaguePoint, int rank) {
-        this.score = leaguePoint;
-        this.rank = rank;
+  public void updateRank(int leaguePoint, int rank) {
+    this.score = leaguePoint;
+    this.rank = rank;
 
-    }
+  }
 
-    /**
-     * Participant 엔티티 리스트 → DraftParticipant 리스트 변환
-     */
-    public static List<DraftParticipant> toDtoList(List<Participant> participants) {
+  /**
+   * Participant 엔티티 리스트 → DraftParticipant 리스트 변환
+   */
+  public static List<DraftParticipant> toDtoList(List<Participant> participants) {
 
-        return participants.stream().map(p -> DraftParticipant.builder()
+    return participants.stream().map(p -> DraftParticipant.builder()
 
-                .participantId(p.getId())
-                .participantUserNumber(p.getUserNumber())
-                .participantDummy(p.isDummy())
+        .participantId(p.getId())
+        .participantUserNumber(p.getUserNumber())
+        .participantDummy(p.isDummy())
 
-                .userEmail(p.getUser() != null ? p.getUser().getEmail() : null)
-                .userName(p.getUser() != null ? p.getUser().getName() : null)
+        .userEmail(p.getUser() != null ? p.getUser().getEmail() : null)
+        .userName(p.getUser() != null ? p.getUser().getName() : null)
 
-                .build()
-        ).collect(Collectors.toList());
-    }
+        .build()
+    ).collect(Collectors.toList());
+  }
 }


### PR DESCRIPTION
Changes
---

- 방 스코어보드정보를 가져오는 getScoreboard() 메서드 구현
- 특정 참가자의 로스터(11명) + 포메이션 계산을 위한 getRoster() 메서드 구현 
- participant 엔티티의 컬럼명 1줄 수정 (is_dummy)

---
#74 

close #74 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 채팅방 별 스코어보드 조회 기능 추가: 참가자별 총점 기준 내림차순 정렬과 순위(1–4위) 제공, 봇 참가자는 구분 표기.
  * 참가자 로스터 조회 기능 추가: 선택한 참가자의 11인 명단과 포메이션(DF-MID-FWD) 정보 제공.
  * 모든 참가자가 점수가 없어도 스코어보드에 표시되며, 동점 시 동일 순위 처리를 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->