### PR TITLE
hotfix - 주소들 수정

### DIFF
--- a/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/MatchWebSocketConfig.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/MatchWebSocketConfig.java
@@ -34,7 +34,7 @@ public class MatchWebSocketConfig implements WebSocketConfigurer {
      * 우선순위: application.properties(frontend.http.url) → ENV(FRONTEND_HTTP_URL) → 기본값(localhost:5173)
      * 예) 운영 배포 시 FRONTEND_HTTP_URL=https://app.example.com
      */
-    @Value("${frontend.http.url:${FRONTEND_HTTP_URL:http://localhost:5173}}")
+    @Value("${frontend.https.url:${FRONTEND_HTTPS_URL:http://localhost:5173}}")
     private String frontendHttpUrl;
 
     @Override

--- a/backendProject/src/main/java/likelion/mlb/backendProject/global/security/oauth/OAuth2SuccessHandler.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/global/security/oauth/OAuth2SuccessHandler.java
@@ -13,7 +13,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @RequiredArgsConstructor
@@ -22,8 +21,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
   private final JwtTokenProvider jwtTokenProvider;
   private final RefreshTokenService refreshTokenService;
 
-  @Value("${frontend.https.url}")
-  private String frontendUrl;
+  @Value("${frontend.https.url:${FRONTEND_HTTPS_URL:http://localhost:5173}}")
+  private String frontendHttpUrl;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request,
@@ -47,10 +46,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     response.addCookie(refreshTokenCookie);
 
     // 액세스 토큰은 URL 파라미터로 전달
-    String targetUrl = UriComponentsBuilder.fromUriString(frontendUrl)
-        .path("/auth/callback")
-        .queryParam("accessToken", accessToken)
-        .build().toUriString();
+    String targetUrl =  frontendHttpUrl + "/auth/callback?accessToken=" + accessToken;
     response.sendRedirect(targetUrl);
   }
 }


### PR DESCRIPTION
matchwebsocket의 http를 https로 변경했습니다.
Oauth2SuccessHandler도 동일합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * HTTPS 기반 프런트엔드 도메인 지원 확대
  * 환경 변수로 프런트엔드 URL을 손쉽게 설정 가능(기본값: http://localhost:5173)

* Bug Fixes
  * 소셜 로그인 후 리다이렉트 동작의 안정성 향상

* Chores
  * WebSocket 허용 오리진을 최신 프런트엔드 URL 체계에 맞게 정비하여 HTTPS 도메인 연결 호환성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->