### PR TITLE
feat(chat): 드래프트 페이지 채팅을 위한 추가 API 구현(#78)

### DIFF
--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatRoomQueryController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatRoomQueryController.java
@@ -7,7 +7,10 @@ import org.springframework.web.bind.annotation.*;
 
 import likelion.mlb.backendProject.domain.chat.dto.ScoreboardItem;
 import likelion.mlb.backendProject.domain.chat.dto.RosterResponse;
+import likelion.mlb.backendProject.domain.chat.entity.ChatRoom;
+import likelion.mlb.backendProject.domain.chat.repository.ChatRoomRepository;
 import likelion.mlb.backendProject.domain.chat.service.ChatRoomQueryService;
+import likelion.mlb.backendProject.domain.chat.service.ChatRoomService;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,6 +18,8 @@ import likelion.mlb.backendProject.domain.chat.service.ChatRoomQueryService;
 public class ChatRoomQueryController {
 
   private final ChatRoomQueryService queryService;
+  private final ChatRoomService chatRoomService;
+  private final ChatRoomRepository chatRoomRepository;
 
   /**
    * 방 스코어보드 (4명, 점수/랭크)
@@ -30,5 +35,32 @@ public class ChatRoomQueryController {
   @GetMapping("/{roomId}/participants/{participantId}/roster")
   public RosterResponse roster(@PathVariable UUID roomId, @PathVariable UUID participantId) {
     return queryService.getRoster(roomId, participantId);
+  }
+
+  /**
+   * 드래프트로 채팅방 조회
+   */
+  @GetMapping("/by-draft/{draftId}")
+  public ChatRoom getChatRoomByDraft(@PathVariable UUID draftId) {
+    return chatRoomRepository.findByDraftId(draftId)
+        .orElseThrow(() -> new IllegalArgumentException("ChatRoom not found for draft " + draftId));
+  }
+
+  /**
+   * 채팅방 생성 (드래프트용)
+   */
+  @PostMapping
+  public ChatRoom createChatRoom(@RequestBody CreateChatRoomRequest request) {
+    return chatRoomService.createForDraft(request.getDraftId());
+  }
+
+  /**
+   * 채팅방 생성 요청 DTO
+   */
+  public static class CreateChatRoomRequest {
+    private UUID draftId;
+    
+    public UUID getDraftId() { return draftId; }
+    public void setDraftId(UUID draftId) { this.draftId = draftId; }
   }
 }


### PR DESCRIPTION
- ChatRoomQueryController API추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 드래프트 기반 채팅방 조회 API 추가: 드래프트 ID로 관련 채팅방을 빠르게 찾을 수 있습니다. 미존재 시 명확한 오류 응답을 제공합니다.
  * 채팅방 생성 API 추가: 간단한 요청으로 특정 드래프트에 연결된 채팅방을 즉시 만들 수 있습니다.
  * 기존 스코어보드/로스터 관련 기능은 변경 없이 그대로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->