### PR TITLE
dev : LOCK_TIME 원복

### DIFF
--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/service/DraftTimingService.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/service/DraftTimingService.java
@@ -40,7 +40,7 @@ public class DraftTimingService {
     private static final ZoneId  UTC       = ZoneOffset.UTC;
     /** 드래프트 오픈/락 시각(정책 상수) — 필요 시 application.properties로 분리 가능 */
     private static final LocalTime OPEN_TIME = LocalTime.of(8, 0);
-    private static final LocalTime LOCK_TIME = LocalTime.of(22, 0);
+    private static final LocalTime LOCK_TIME = LocalTime.of(17, 5);
 
     /**
      * "현재 시각 이후" 첫 라운드의 드래프트 윈도우를 반환한다.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 드래프트 잠금 시간이 드래프트 당일 22:00에서 17:05(KST)로 변경되었습니다.
  - 드래프트 오픈 시간은 08:00(KST)로 유지되며, 모든 라운드에 동일하게 적용됩니다.
  - 경기 시작 시간 기준 KST 변환 로직은 기존과 동일하며, 이에 따라 픽/라인업 변경 마감이 더 이르게 도래합니다.
  - 예정된 드래프트 일정과 알림을 확인해 주시기 바랍니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->