### PR TITLE
dev : 드래프트 기능 수정

### DIFF
--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/controller/TurnController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/controller/TurnController.java
@@ -1,0 +1,40 @@
+package likelion.mlb.backendProject.domain.draft.controller;
+
+
+import likelion.mlb.backendProject.domain.draft.dto.StartTurnRequest;
+import likelion.mlb.backendProject.domain.draft.service.TurnService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/draft")
+@RequiredArgsConstructor
+public class TurnController {
+
+    private final TurnService turnService;
+
+    /**
+     * [POST] 현재 턴/라운드 설정 + 타이머 시작 + 즉시 브로드캐스트
+     * body: { currentParticipantId, roundNo, pickWindowSec? }
+     */
+    @PostMapping("/{roomId}/turn")
+    public ResponseEntity<Void> startOrUpdateTurn(
+            @PathVariable UUID roomId,
+            @RequestBody StartTurnRequest req
+    ) {
+        turnService.startOrUpdateTurn(roomId, req);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * [POST] 스냅샷 1회 재전송 (클라가 재동기화할 때 유용)
+     */
+    @PostMapping("/{roomId}/turn/snapshot")
+    public ResponseEntity<Void> snapshot(@PathVariable UUID roomId) {
+        turnService.broadcastTurnOnce(roomId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/DraftRequest.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/DraftRequest.java
@@ -1,5 +1,6 @@
 package likelion.mlb.backendProject.domain.draft.dto;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,6 +14,8 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class DraftRequest {
+
+    private String type; // 요청 타입
 
     private UUID draftId; // 드래프트 방 pk값
 
@@ -43,5 +46,14 @@ public class DraftRequest {
 
     // 한 참가자가 선수를 드래프트 했을 시 포지션 별 최대/최소 값 유지하는 지 여부
     private boolean isWithinSquadLimits = true;
+
+    // 현재 드래프트한 참가자가 현재 턴인지 유무
+    private boolean isCurrentParticipant = true;
+
+    private short nextUserNumber;
+
+    private short roundNo;
+
+    private Integer draftCnt;
 
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/StartTurnRequest.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/StartTurnRequest.java
@@ -1,0 +1,10 @@
+package likelion.mlb.backendProject.domain.draft.dto;
+
+import java.util.UUID;
+
+public record StartTurnRequest(
+        UUID currentParticipantId,
+        Integer roundNo,        // 1..11
+        Integer pickWindowSec,   // null이면 기본 60초
+        Integer draftCnt // 해당 드래프트 룸에서 현재까지 몇 명 드래프트 했는지
+) {}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/TurnSnapshot.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/dto/TurnSnapshot.java
@@ -1,0 +1,12 @@
+package likelion.mlb.backendProject.domain.draft.dto;
+
+import java.util.UUID;
+
+public record TurnSnapshot(
+        String type,        // "TURN_SNAPSHOT"
+        UUID roomId,
+        String currentParticipantId,
+        int roundNo,        // 1..11
+        int remainingSec,   // 서버 계산 남은 초
+        long deadlineAt     // epoch ms (클라가 보정용으로 사용)
+) {}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/service/TurnService.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/service/TurnService.java
@@ -1,0 +1,110 @@
+package likelion.mlb.backendProject.domain.draft.service;
+
+import likelion.mlb.backendProject.domain.draft.dto.DraftRequest;
+import likelion.mlb.backendProject.domain.draft.dto.StartTurnRequest;
+import likelion.mlb.backendProject.domain.draft.dto.TurnSnapshot;
+import likelion.mlb.backendProject.domain.draft.util.DraftKeys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TurnService {
+
+    private final StringRedisTemplate redis;
+    private final SimpMessagingTemplate messaging;
+
+    /**
+     * 현재 턴 시작/갱신:
+     * - Redis 해시에 currentParticipantId, roundNo, deadlineAt 저장
+     * - 타이머 키에 TTL 설정
+     * - STOMP로 스냅샷 즉시 브로드캐스트
+     */
+    public void startOrUpdateTurn(UUID roomId, StartTurnRequest req) {
+        String stateKey = DraftKeys.state(roomId);
+        String timerKey = DraftKeys.timer(roomId);
+
+        int winSec = (req.pickWindowSec() == null) ? 60 : req.pickWindowSec();
+        long now = Instant.now().toEpochMilli();
+        long deadlineAt = now + winSec * 1000L;
+
+        Map<String, String> m = new HashMap<>();
+        m.put("currentParticipantId", req.currentParticipantId().toString());
+        m.put("roundNo", String.valueOf(req.roundNo()));
+        m.put("deadlineAt", String.valueOf(deadlineAt));
+        m.put("updatedAt", String.valueOf(now));
+        m.put("draftCnt", String.valueOf(req.draftCnt()));
+        redis.opsForHash().putAll(stateKey, m);
+
+        // 타이머 TTL: 키 값은 검증/디버깅용으로 deadlineAt 저장(원하는 값으로 대체 가능)
+//        redis.opsForValue().set(timerKey, String.valueOf(deadlineAt), winSec, TimeUnit.SECONDS);
+
+        // 바로 한 번 쏘기
+//        broadcastTurnOnce(roomId);
+    }
+
+    /**
+     * Redis 상태를 읽어 한 번 브로드캐스트 (누구 턴/몇 라운드/남은 초)
+     */
+    public void broadcastTurnOnce(UUID roomId) {
+        String stateKey = DraftKeys.state(roomId);
+        String timerKey = DraftKeys.timer(roomId);
+
+        var vals = redis.opsForHash().multiGet(stateKey, Arrays.asList("currentParticipantId", "roundNo", "deadlineAt"));
+        if (vals == null || vals.get(0) == null || vals.get(1) == null || vals.get(2) == null) return;
+
+        String currentParticipantId = (String) vals.get(0);
+        int roundNo = Integer.parseInt((String) vals.get(1));
+        long deadlineAt = Long.parseLong((String) vals.get(2));
+
+        // 남은 초 (deadline 기준)
+        long now = Instant.now().toEpochMilli();
+        int remainingByDeadline = (int) Math.max(0, (deadlineAt - now) / 1000);
+
+        // 보정: timer TTL이 있으면 TTL 우선
+        Long ttl = redis.getExpire(timerKey, TimeUnit.SECONDS); // -2 없음, -1 TTL 없음
+        int remainingSec = (ttl != null && ttl >= 0) ? ttl.intValue() : remainingByDeadline;
+
+        TurnSnapshot payload = new TurnSnapshot(
+                "TURN_SNAPSHOT", roomId, currentParticipantId, roundNo, remainingSec, deadlineAt
+        );
+        messaging.convertAndSend(DraftKeys.topic(roomId), payload);
+    }
+
+    public boolean checkCurrentParticipant(DraftRequest draftRequest) {
+        UUID draftId = draftRequest.getDraftId();
+        UUID participantId = draftRequest.getParticipantId();
+
+        String stateKey = DraftKeys.state(draftId);
+//        String timerKey = DraftKeys.timer(draftId);
+
+
+        var vals = redis.opsForHash().multiGet(stateKey, Arrays.asList("currentParticipantId"));
+        if ( vals == null || vals.get(0) == null || ((String)vals.get(0)).trim().equals("") ) return false;
+
+        UUID currentParticipantId = UUID.fromString((String)vals.get(0));
+
+        if(participantId.equals(currentParticipantId)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public Integer getDraftCnt(UUID draftID) {
+
+        String stateKey = DraftKeys.state(draftID);
+        var vals = redis.opsForHash().multiGet(stateKey, Arrays.asList("draftCnt"));
+        if (vals == null || vals.get(0) == null || ((String)vals.get(0)).trim().equals("")
+        || ((String)vals.get(0)).trim().equals("null")) return 0;
+
+
+        return Integer.parseInt((String)vals.get(0));
+    }
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/util/DraftKeys.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/util/DraftKeys.java
@@ -1,0 +1,9 @@
+package likelion.mlb.backendProject.domain.draft.util;
+
+import java.util.UUID;
+
+public class DraftKeys {
+    public static String state(UUID roomId) { return "draft:"+roomId+":state"; }
+    public static String timer(UUID roomId) { return "draft:"+roomId+":timer"; }
+    public static String topic(UUID roomId) { return "/topic/draft."+roomId; }
+}

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/repository/ParticipantRepository.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/match/repository/ParticipantRepository.java
@@ -47,4 +47,7 @@ public interface ParticipantRepository extends JpaRepository<Participant, UUID> 
     java.util.List<likelion.mlb.backendProject.domain.match.entity.Participant>
     findLatestByUser(@Param("userId") java.util.UUID userId,
         org.springframework.data.domain.Pageable pageable);
+
+
+    Optional<Participant> findByDraftAndUserNumber(Draft draft, short userNumber);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 드래프트 턴 관리 추가: 현재 참가자, 라운드, 남은 시간/마감 시각을 실시간 스냅샷으로 브로드캐스트.
  * API 제공: 턴 시작/갱신, 스냅샷 재전송(재동기화) 엔드포인트.
  * 턴 타이머 지원(기본 60초) 및 클라이언트 보정용 마감 시각 전달.
  * 선택 동작 검증 강화: 현재 참가자만 선택이 반영되며, 성공 시 자동으로 다음 턴으로 진행.
  * 스네이크 방식(라운드에 따른 순서 역전)으로 다음 참가자 계산.
  * 무작위 선택도 턴 규칙을 준수하여 처리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->