### PR TITLE
[Documnet] 스웨거 정리 및 스웨거 페이지별 그룹 처리(#78)

### DIFF
--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/bus/ChatRedisPublisher.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/bus/ChatRedisPublisher.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
-//@Component  // Redis 방식 비활성화
+@Component
 @RequiredArgsConstructor
 public class ChatRedisPublisher {
 

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/bus/ChatRedisSubscriber.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/bus/ChatRedisSubscriber.java
@@ -9,7 +9,7 @@ import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
-//@Component  // Redis 방식 비활성화
+@Component
 @RequiredArgsConstructor
 public class ChatRedisSubscriber implements MessageListener {
 

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/bus/RedisPubSubConfig.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/bus/RedisPubSubConfig.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 
-//@Configuration  // Redis 방식 비활성화
+@Configuration
 @RequiredArgsConstructor
 public class RedisPubSubConfig {
 

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatHistoryController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatHistoryController.java
@@ -7,6 +7,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Tag(name = "Chat History", description = "채팅 히스토리 조회 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat-rooms")
@@ -14,20 +21,29 @@ public class ChatHistoryController {
 
   private final ChatHistoryService chatHistoryService;
 
-  /** 최신 30개 */
+  @Operation(summary = "최신 채팅 메시지 조회", description = "채팅방의 최신 메시지들을 지정된 개수만큼 조회합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "메시지 조회 성공"),
+      @ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없음")
+  })
   @GetMapping("/{roomId}/messages")
   public ResponseEntity<ChatHistoryPage> latest(
-      @PathVariable UUID roomId,
-      @RequestParam(defaultValue = "30") int limit) {
+      @Parameter(description = "채팅방 ID", required = true) @PathVariable UUID roomId,
+      @Parameter(description = "조회할 메시지 개수 (기본값: 30)") @RequestParam(defaultValue = "30") int limit) {
     return ResponseEntity.ok(chatHistoryService.loadLatest(roomId, limit));
   }
 
-  /** 이전 페이지(커서 기반) */
+  @Operation(summary = "이전 채팅 메시지 조회", description = "커서 기반으로 이전 메시지들을 조회합니다 (무한스크롤용)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "메시지 조회 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 커서 값"),
+      @ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없음")
+  })
   @GetMapping("/{roomId}/messages/before")
   public ResponseEntity<ChatHistoryPage> before(
-      @PathVariable UUID roomId,
-      @RequestParam String cursor,
-      @RequestParam(defaultValue = "30") int limit) {
+      @Parameter(description = "채팅방 ID", required = true) @PathVariable UUID roomId,
+      @Parameter(description = "페이지 커서 (이전 조회의 nextCursor 값)", required = true) @RequestParam String cursor,
+      @Parameter(description = "조회할 메시지 개수 (기본값: 30)") @RequestParam(defaultValue = "30") int limit) {
     return ResponseEntity.ok(chatHistoryService.loadBefore(roomId, cursor, limit));
   }
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatMessagingController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatMessagingController.java
@@ -4,7 +4,7 @@ package likelion.mlb.backendProject.domain.chat.controller;
 import java.security.Principal;
 import java.util.Map;
 import java.util.UUID;
-//import likelion.mlb.backendProject.domain.chat.bus.ChatRedisPublisher;
+import likelion.mlb.backendProject.domain.chat.bus.ChatRedisPublisher;
 import likelion.mlb.backendProject.domain.chat.dto.ChatSendRequest;
 import likelion.mlb.backendProject.domain.chat.repository.ChatMembershipRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class ChatMessagingController {
   private final ChatMessageService chatMessageService;
   private final SimpMessagingTemplate messagingTemplate;
   private final ChatMembershipRepository membershipRepository;
-  //private final ChatRedisPublisher chatRedisPublisher;
+  private final ChatRedisPublisher chatRedisPublisher;
 
 
   @MessageMapping("/chat/{roomId}/send")
@@ -55,11 +55,7 @@ public class ChatMessagingController {
         "createdAt", saved.getCreatedAt().toString()
     );
 
-    // Redis 대신 직접 WebSocket으로 전송 (즉시 전달)
-    String topic = "/topic/chat/" + roomId;
-    messagingTemplate.convertAndSend(topic, payload);
-    
-    // Redis 방식 (주석처리 - 지연 발생)
-    //chatRedisPublisher.publishToRoom(roomId, new java.util.HashMap<>(payload));
+    // Redis pub/sub 방식으로 전송
+    chatRedisPublisher.publishToRoom(roomId, new java.util.HashMap<>(payload));
   }
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatReadController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatReadController.java
@@ -11,6 +11,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+@Tag(name = "Chat Read State", description = "채팅 만음 상태 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat-rooms")
@@ -20,8 +27,16 @@ public class ChatReadController {
   private final ChatReadService chatReadService;
   private final ChatMembershipRepository membershipRepository;
 
+  @Operation(summary = "릶음 상태 조회", description = "사용자의 마지막 읽은 메시지와 미읽 개수를 조회합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "읽음 상태 조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "채팅방 멤버가 아님"),
+      @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+  })
   @GetMapping("/{roomId}/read-state")
-  public ResponseEntity<?> getReadState(@PathVariable UUID roomId,
+  public ResponseEntity<?> getReadState(
+      @Parameter(description = "채팅방 ID", required = true) @PathVariable UUID roomId,
       @AuthenticationPrincipal CustomUserDetails cud) {
     if (cud == null || cud.getUser() == null) {
       log.debug("[read-state] 401: no principal");
@@ -46,9 +61,18 @@ public class ChatReadController {
     }
   }
 
+  @Operation(summary = "메시지 읽음 처리", description = "지정된 메시지까지 읽음으로 표시합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "읽음 처리 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 메시지 ID"),
+      @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+      @ApiResponse(responseCode = "403", description = "채팅방 멤버가 아님"),
+      @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+  })
   @PostMapping("/{roomId}/read-state")
-  public ResponseEntity<?> markRead(@PathVariable UUID roomId,
-      @RequestBody(required = false) Map<String, String> body,
+  public ResponseEntity<?> markRead(
+      @Parameter(description = "채팅방 ID", required = true) @PathVariable UUID roomId,
+      @Parameter(description = "읽음 요청 데이터 (messageId 포함)") @RequestBody(required = false) Map<String, String> body,
       @AuthenticationPrincipal CustomUserDetails cud) {
     if (cud == null || cud.getUser() == null) {
       log.debug("[mark-read] 401: no principal");

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatRoomQueryController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/controller/ChatRoomQueryController.java
@@ -12,6 +12,13 @@ import likelion.mlb.backendProject.domain.chat.repository.ChatRoomRepository;
 import likelion.mlb.backendProject.domain.chat.service.ChatRoomQueryService;
 import likelion.mlb.backendProject.domain.chat.service.ChatRoomService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Tag(name = "Chat Room", description = "채팅방 조회 및 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat-rooms")
@@ -21,36 +28,46 @@ public class ChatRoomQueryController {
   private final ChatRoomService chatRoomService;
   private final ChatRoomRepository chatRoomRepository;
 
-  /**
-   * 방 스코어보드 (4명, 점수/랭크)
-   */
+  @Operation(summary = "채팅방 스코어보드 조회", description = "채팅방 참가자들의 점수와 순위를 조회합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "스코어보드 조회 성공"),
+      @ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없음")
+  })
   @GetMapping("/{roomId}/scoreboard")
-  public List<ScoreboardItem> scoreboard(@PathVariable UUID roomId) {
+  public List<ScoreboardItem> scoreboard(@Parameter(description = "채팅방 ID", required = true) @PathVariable UUID roomId) {
     return queryService.getScoreboard(roomId);
   }
 
-  /**
-   * 특정 참가자의 로스터(11인) + 포메이션
-   */
+  @Operation(summary = "참가자 로스터 조회", description = "특정 참가자의 11명 로스터와 포메이션 정보를 조회합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "로스터 조회 성공"),
+      @ApiResponse(responseCode = "404", description = "참가자를 찾을 수 없음")
+  })
   @GetMapping("/{roomId}/participants/{participantId}/roster")
-  public RosterResponse roster(@PathVariable UUID roomId, @PathVariable UUID participantId) {
+  public RosterResponse roster(
+      @Parameter(description = "채팅방 ID", required = true) @PathVariable UUID roomId,
+      @Parameter(description = "참가자 ID", required = true) @PathVariable UUID participantId) {
     return queryService.getRoster(roomId, participantId);
   }
 
-  /**
-   * 드래프트로 채팅방 조회
-   */
+  @Operation(summary = "드래프트 채팅방 조회", description = "드래프트 ID로 해당 채팅방을 조회합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "채팅방 조회 성공"),
+      @ApiResponse(responseCode = "404", description = "드래프트에 해당하는 채팅방을 찾을 수 없음")
+  })
   @GetMapping("/by-draft/{draftId}")
-  public ChatRoom getChatRoomByDraft(@PathVariable UUID draftId) {
+  public ChatRoom getChatRoomByDraft(@Parameter(description = "드래프트 ID", required = true) @PathVariable UUID draftId) {
     return chatRoomRepository.findByDraftId(draftId)
         .orElseThrow(() -> new IllegalArgumentException("ChatRoom not found for draft " + draftId));
   }
 
-  /**
-   * 채팅방 생성 (드래프트용)
-   */
+  @Operation(summary = "채팅방 생성", description = "드래프트를 위한 새 채팅방을 생성합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "채팅방 생성 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
+  })
   @PostMapping
-  public ChatRoom createChatRoom(@RequestBody CreateChatRoomRequest request) {
+  public ChatRoom createChatRoom(@Parameter(description = "채팅방 생성 요청") @RequestBody CreateChatRoomRequest request) {
     return chatRoomService.createForDraft(request.getDraftId());
   }
 

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/elasticsearch/ChatReindexController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/elasticsearch/ChatReindexController.java
@@ -8,6 +8,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Tag(name = "Chat Search Management", description = "채팅 검색 인덱스 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat-rooms")
@@ -15,8 +22,14 @@ public class ChatReindexController {
   private final ChatMessageRepository repo;
   private final ChatSearchIndexer indexer;
 
+  @Operation(summary = "채팅 메시지 재인덱싱", description = "지정된 채팅방의 모든 메시지를 Elasticsearch에 재인덱싱합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "재인덱싱 성공"),
+      @ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+  })
   @PostMapping("/{roomId}/reindex")
-  public void reindex(@PathVariable UUID roomId) {
+  public void reindex(@Parameter(description = "채팅방 ID", required = true) @PathVariable UUID roomId) {
     // 대용량이면 Page로 분할 처리
     repo.findAllByChatRoomIdOrderByCreatedAtAsc(roomId).forEach(indexer::index);
   }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/elasticsearch/controller/ChatSearchController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/chat/elasticsearch/controller/ChatSearchController.java
@@ -11,6 +11,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Tag(name = "Chat Search", description = "채팅 메시지 검색 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat-rooms")
@@ -19,12 +26,18 @@ public class ChatSearchController {
   private final ChatSearchService chatSearchService;
   private final ChatMembershipRepository membershipRepository;
 
+  @Operation(summary = "채팅 메시지 검색", description = "지정된 채팅방에서 키워드로 메시지를 검색합니다")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "검색 성공"),
+      @ApiResponse(responseCode = "403", description = "채팅방 멤버가 아님"),
+      @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+  })
   @GetMapping("/{roomId}/search")
   public ResponseEntity<ChatSearchResult> search(
-      @PathVariable UUID roomId,
-      @RequestParam(required = false, defaultValue = "") String q,
-      @RequestParam(required = false) String cursor,
-      @RequestParam(defaultValue = "20") int limit,
+      @Parameter(description = "채팅방 ID", required = true) @PathVariable UUID roomId,
+      @Parameter(description = "검색 키워드") @RequestParam(required = false, defaultValue = "") String q,
+      @Parameter(description = "페이지 커서 (이전 조회의 nextCursor 값)") @RequestParam(required = false) String cursor,
+      @Parameter(description = "조회할 메시지 개수 (1-50, 기본값: 20)") @RequestParam(defaultValue = "20") int limit,
       Authentication authentication) {
 
     // 권한 체크

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/controller/DraftController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/draft/controller/DraftController.java
@@ -15,12 +15,19 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
 import java.security.Principal;
 import java.util.*;
 
 /**
  * 드래프트 관련 controller
  * */
+@Tag(name = "Draft", description = "드래프트 관리 API")
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/draft")
@@ -48,41 +55,53 @@ public class DraftController {
         }
     }
 
-    /*
-    * 참여자(participant)클릭 시 해당 참여자가 선택한 선수 리스트 가져오기
-    * */
+    @Operation(summary = "참여자별 선수 목록 조회", description = "특정 참여자가 선택한 선수 리스트를 조회합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "선수 목록 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "참여자를 찾을 수 없음")
+    })
     @GetMapping("/{participantId}/players")
     @ResponseBody
-    public List<DraftResponse> getPlayersByParticipantId(@PathVariable("participantId") UUID participantId) {
+    public List<DraftResponse> getPlayersByParticipantId(
+        @Parameter(description = "참여자 ID", required = true) @PathVariable("participantId") UUID participantId) {
         return draftService.getPlayersByParticipantId(participantId);
     }
 
 
-    /*
-     * 드래프트 방 입장 시 해당 드래프트 방에 속해 있는 4명의 참여자 리스트 가져오기
-     */
+    @Operation(summary = "드래프트 참여자 목록 조회", description = "드래프트 방에 속해있는 참여자 목록을 조회합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "참여자 목록 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "드래프트를 찾을 수 없음")
+    })
     @GetMapping("/{draftId}/participants")
     @ResponseBody
-    public List<DraftParticipant> getParticipantsByDraftId(@PathVariable("draftId") UUID draftId) {
+    public List<DraftParticipant> getParticipantsByDraftId(
+        @Parameter(description = "드래프트 ID", required = true) @PathVariable("draftId") UUID draftId) {
         return draftService.getParticipantsByDraftId(draftId);
     }
 
-    /*
-     * 해당 드래프트 방에서 선택 된 선수 리스트 가져오기
-     */
+    @Operation(summary = "드래프트 전체 선수 목록 조회", description = "드래프트에서 선택된 모든 선수 목록을 조회합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "선수 목록 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "드래프트를 찾을 수 없음")
+    })
     @GetMapping("/{draftId}/allPlayers")
     @ResponseBody
-    public List<DraftResponse> getAllPlayersByDraftId(@PathVariable("draftId") UUID draftId) {
+    public List<DraftResponse> getAllPlayersByDraftId(
+        @Parameter(description = "드래프트 ID", required = true) @PathVariable("draftId") UUID draftId) {
         return draftService.getAllPlayersByDraftId(draftId);
     }
 
-    /*
-     * isWithinSquadLimits테스트용
-     */
+    @Operation(summary = "스쿼드 제한 검사", description = "참여자의 스쿼드 제한을 검사합니다 (테스트용)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "검사 완료"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터")
+    })
     @GetMapping("squadLimit")
     @ResponseBody
-    public boolean isWithinSquadLimits(@RequestParam(value="participantId") UUID participantId,
-                                                      @RequestParam(value="participantId")UUID elementTypeId) {
+    public boolean isWithinSquadLimits(
+        @Parameter(description = "참여자 ID", required = true) @RequestParam(value="participantId") UUID participantId,
+        @Parameter(description = "엘리먼트 타입 ID", required = true) @RequestParam(value="elementTypeId")UUID elementTypeId) {
         return draftService.isWithinSquadLimitsTest(participantId, elementTypeId);
     }
 }

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/player/cache/controller/PlayerCacheController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/player/cache/controller/PlayerCacheController.java
@@ -11,8 +11,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
 import java.util.*;
 
+@Tag(name = "Player Cache", description = "선수 캐시 관리 API")
 @RestController
 @RequestMapping("/api/playerCache")
 @RequiredArgsConstructor
@@ -20,14 +26,22 @@ public class PlayerCacheController {
 
     private final PlayerCacheService playerCacheService;
 
-    // DB → Redis 저장 (캐시 초기화)
+    @Operation(summary = "선수 데이터 캐시링", description = "DB의 선수 데이터를 Redis 캐시로 로드합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "캐시링 성공"),
+        @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+    })
     @PostMapping("/cache")
     public ResponseEntity<String> cachePlayerList() {
         playerCacheService.loadPlayersToRedis();
         return ResponseEntity.ok("Player list cached to Redis.");
     }
 
-    // Redis → 조회 (캐시 미스 시 자동 로드)
+    @Operation(summary = "선수 목록 조회", description = "Redis 캐시에서 선수 목록을 조회합니다 (캐시 미스 시 DB에서 자동 로드)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "선수 목록 조회 성공"),
+        @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+    })
     @GetMapping
     public ResponseEntity<List<PlayerDto>> getPlayerList() {
         List<PlayerDto> playerList = playerCacheService.getPlayersFromRedis();

--- a/backendProject/src/main/java/likelion/mlb/backendProject/domain/player/elasticsearch/controller/PlayerEsController.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/domain/player/elasticsearch/controller/PlayerEsController.java
@@ -11,10 +11,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
+@Tag(name = "Player Search", description = "선수 검색 API (Elasticsearch)")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/playerEs")
@@ -22,11 +29,16 @@ public class PlayerEsController {
 
     private final PlayerEsService playerEsService;
 
-    // elasticsearch 검색 결과를 json List로 반환
+    @Operation(summary = "선수 검색", description = "키워드와 엘리먼트 타입으로 선수를 검색합니다")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "검색 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 검색 파라미터"),
+        @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+    })
     @GetMapping("/search")
     public ResponseEntity<List<PlayerEsDocument>> searchWithKeyword(
-            @RequestParam(value = "keyword", defaultValue = "") String keyword
-            , @RequestParam(value = "elementTypeId", defaultValue = "") String elementTypeId
+            @Parameter(description = "검색 키워드 (선수명 등)") @RequestParam(value = "keyword", defaultValue = "") String keyword,
+            @Parameter(description = "엘리먼트 타입 ID") @RequestParam(value = "elementTypeId", defaultValue = "") String elementTypeId
             ) {
 
         return ResponseEntity.ok(playerEsService.search(keyword, elementTypeId));

--- a/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/OpenApiConfig.java
+++ b/backendProject/src/main/java/likelion/mlb/backendProject/global/configuration/OpenApiConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,6 +33,96 @@ public class OpenApiConfig {
             .info(info)
             .addSecurityItem(securityRequirement)
             .components(components);
+    }
+
+    @Bean
+    public GroupedOpenApi chatApi() {
+        return GroupedOpenApi.builder()
+            .group("Chat API")
+            .pathsToMatch("/api/chat-rooms/**", "/api/notify/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.chat")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi chatSearchApi() {
+        return GroupedOpenApi.builder()
+            .group("Chat Search API")
+            .pathsToMatch("/api/chat-rooms/*/search/**", "/api/chat-rooms/*/reindex/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.chat.elasticsearch")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi userApi() {
+        return GroupedOpenApi.builder()
+            .group("User API")
+            .pathsToMatch("/api/user/**", "/api/auth/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.user")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi draftApi() {
+        return GroupedOpenApi.builder()
+            .group("Draft API")
+            .pathsToMatch("/api/draft/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.draft")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi playerApi() {
+        return GroupedOpenApi.builder()
+            .group("Player API")
+            .pathsToMatch("/api/player/**", "/api/elementType/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.player")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi playerCacheApi() {
+        return GroupedOpenApi.builder()
+            .group("Player Cache API")
+            .pathsToMatch("/api/playerCache/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.player.cache")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi playerEsApi() {
+        return GroupedOpenApi.builder()
+            .group("Player Search API")
+            .pathsToMatch("/api/playerEs/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.player.elasticsearch")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi matchApi() {
+        return GroupedOpenApi.builder()
+            .group("Match API")
+            .pathsToMatch("/api/match/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.match")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi teamApi() {
+        return GroupedOpenApi.builder()
+            .group("Team API")
+            .pathsToMatch("/api/team/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.team")
+            .build();
+    }
+
+    @Bean
+    public GroupedOpenApi roundApi() {
+        return GroupedOpenApi.builder()
+            .group("Round API")
+            .pathsToMatch("/api/round/**")
+            .packagesToScan("likelion.mlb.backendProject.domain.round")
+            .build();
     }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Redis 기반 채팅 메시지/알림 브로드캐스트를 활성화하여 채팅방 전달 경로를 확장했습니다.
  - OpenAPI 문서를 도메인별 그룹(채팅, 채팅검색, 유저, 드래프트, 선수, 선수캐시, 선수검색, 매치, 팀, 라운드)으로 분리했습니다.

- Documentation
  - 다수의 API에 태그, 요약, 응답 코드, 파라미터 설명을 추가했습니다: 채팅 히스토리/읽음/방 조회·관리, 알림, 채팅 검색/재인덱싱, 드래프트, 선수 캐시·검색.
  - Swagger UI에서 가독성과 탐색성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->